### PR TITLE
Just exit with nonzero to halt.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       
       - name: Read bump tag
         run: |
-          echo ((Test-Path ./bump.tag) ? (Get-Content ./bump.tag) : "::setFailed './bump.tag not found'")
+          echo ((Test-Path ./bump.tag) ? (Get-Content ./bump.tag) : (exit 1))
       
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
GH Docs can't be trusted.
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#using-workflow-commands-to-access-toolkit-functions Bunch of misleading BS.
![image](https://user-images.githubusercontent.com/4364856/209495789-b87e599c-e732-4186-80d2-04af006f76c2.png)
